### PR TITLE
Add Vitest tests for utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -78,6 +79,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('cn', () => {
+  it('joins class names with a space', () => {
+    expect(cn('a', 'b')).toBe('a b')
+  })
+
+  it('merges conflicting classes correctly', () => {
+    expect(cn('px-2', 'px-4')).toBe('px-4')
+  })
+})


### PR DESCRIPTION
## Summary
- add Vitest test suite for `cn` util
- wire Vitest to `npm test`

## Testing
- `npm test` *(fails: vitest not found)*