### PR TITLE
Update dev setup docs with Vite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ npm i
 npm run dev
 ```
 
+Running `npm run dev` will start Vite on [http://localhost:8080](http://localhost:8080) as configured in `vite.config.ts`. Visit this URL to access the app.
+
 ## Deployment
 
 The application can be deployed to any static site hosting service such as Vercel, Netlify, or GitHub Pages.


### PR DESCRIPTION
## Summary
- document Vite's dev server URL in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Development Setup instructions in the README to clarify that the app runs on http://localhost:8080 and to guide users to visit this URL when starting the development server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->