### PR TITLE
Fix toast listener effect dependencies

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure useEffect registering toast listener only runs once on mount

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*