### PR TITLE
Fix duplicate listener bug in toast hook

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -171,6 +171,9 @@ function toast({ ...props }: Toast) {
 function useToast() {
   const [state, setState] = React.useState<State>(memoryState)
 
+  // Subscribe once to state updates on mount.
+  // Using [state] here would re-subscribe every time the state changes,
+  // leading to duplicate listeners and memory leaks.
   React.useEffect(() => {
     listeners.push(setState)
     return () => {
@@ -179,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent useToast from adding duplicate listeners by removing `state` from dependency array and documenting why

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*